### PR TITLE
split `HomeBlockProps` into `TitleBlockProps`, `HomeBlockProps` and `ProjectCarouselBlockProps`

### DIFF
--- a/src/components/HomeProjectsBlock.tsx
+++ b/src/components/HomeProjectsBlock.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { HomeBlockProps } from '../interfaces/HomeBlockProps';
+import { ProjectCarouselBlockProps } from '../interfaces/ProjectCarouselBlockProps';
 
 import { Link } from 'react-router-dom';
 
@@ -37,7 +37,7 @@ const swiperConfig = {
   modules: [EffectCoverflow, Navigation, Pagination],
   className: 'projectsSwiper',
 };
-const HomeProjectsBlock = (props: HomeBlockProps) => (
+const HomeProjectsBlock = (props: ProjectCarouselBlockProps) => (
   <HomeProjectsBlockDiv>
     <Carousel>
       <Swiper {...swiperConfig}>

--- a/src/components/ProjectsTextMultiCarousel.tsx
+++ b/src/components/ProjectsTextMultiCarousel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { HomeBlockProps } from '../interfaces/HomeBlockProps';
+import { ProjectCarouselBlockProps } from '../interfaces/ProjectCarouselBlockProps';
 import ProjectCard from './ProjectTextCard';
 
 import { Splide, SplideSlide, SplideTrack, Options } from '@splidejs/react-splide';
@@ -10,7 +10,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { icon } from '@fortawesome/fontawesome-svg-core/import.macro';
 
 
-const ProjectsTextMultiCarousel = ({ content }: HomeBlockProps) => {
+const ProjectsTextMultiCarousel = ({ content }: ProjectCarouselBlockProps) => {
 
   const [renderCarousel, setRenderCarousel] = useState<boolean>(false); 
   // if we don't use this state, the breakpoints don't take effect

--- a/src/components/TitleBlock.tsx
+++ b/src/components/TitleBlock.tsx
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import Button from './Button';
 
-import { HomeBlockProps } from '../interfaces/HomeBlockProps';
+import { TitleBlockProps } from '../interfaces/TitleBlockProps';
 
-const TitleBlock = (props: HomeBlockProps) => (
+const TitleBlock = (props: TitleBlockProps) => (
   <TitleBlockDiv>
     <Title>{props.content.title}</Title>
     <Description>{props.content.subtitle}</Description>

--- a/src/interfaces/ProjectCarouselBlockProps.tsx
+++ b/src/interfaces/ProjectCarouselBlockProps.tsx
@@ -1,0 +1,11 @@
+import {IProject} from "../static/json/projectDetails";
+
+export interface ProjectCarouselBlockProps {
+  content: {
+    buttons: {
+      content: string;
+      link: string;
+    }[];
+    slider: IProject[];
+  };
+}

--- a/src/interfaces/TitleBlockProps.tsx
+++ b/src/interfaces/TitleBlockProps.tsx
@@ -1,12 +1,12 @@
-export interface HomeBlockProps {
+export interface TitleBlockProps {
   content: {
     title: string;
     subtitle: string;
     image: {
       picture: any;
       alt: string;
+      border?: boolean;
     };
-    style: string;
     buttons: {
       content: string;
       link: string;


### PR DESCRIPTION
No visible changes on the front end. 

Just split an overgeneralized `HomeBlockProps` interface into 3. 